### PR TITLE
Fix command-line argument parsing of integers for vquest options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,10 @@
  * `--align` argument (via `airr_to_fasta` function) for exraction of sequence
    alignment FASTA from AIRR results ([#1])
 
+### Fixed
+
+ * Parse command-line options that should be integers from a finite list of
+   options as integers instead of strings ([#5])
+
+[#5]: https://github.com/ressy/vquest/pull/5
 [#1]: https://github.com/ressy/vquest/pull/1

--- a/test_vquest.py
+++ b/test_vquest.py
@@ -20,8 +20,8 @@ import vquest.__main__
 
 DATA = Path(__file__).parent / "vquest" / "data" / "tests"
 
-class TestVquest(unittest.TestCase):
-    """Basic test of vquest."""
+class TestVquestBase(unittest.TestCase):
+    """Base class for supporting code.  No actual tests here."""
 
     def setUp(self):
         self.case = "basic"
@@ -49,6 +49,10 @@ class TestVquest(unittest.TestCase):
         """Put back original post function after testing."""
         reqs = sys.modules["requests"]
         reqs.post = reqs.post_real
+
+
+class TestVquest(TestVquestBase):
+    """Basic test of vquest."""
 
     def test_vquest(self):
         """Test that a basic request gives the expected response."""

--- a/test_vquest.py
+++ b/test_vquest.py
@@ -255,3 +255,12 @@ AGCCGGGTGGAAGCTGAGGATGTTGGGGTGTATTACTGTATGCAAAGTATAGAGTTTCCTCC"""}
             deletions,
             ("in CDR1-IMGT, from codon 33 of V-REGION: 3 nucleotides "
             "(from position 97 in the user submitted sequence), (do not cause frameshift)"))
+
+    def test_vquest_main(self):
+        """Try an extra argument given as though on the command line."""
+        config_path = str(DATA / (self.case + "_config.yml"))
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chdir(tempdir)
+            vquest.__main__.main(["--imgtrefdirset", "1", config_path])
+            self.assertTrue(Path("vquest_airr.tsv").exists())
+            self.assertTrue(Path("Parameters.txt").exists())

--- a/vquest/__main__.py
+++ b/vquest/__main__.py
@@ -83,11 +83,16 @@ def __setup_arg_parser():
         for optname, opt in opt_section["options"].items():
             args = {
                 "help": opt["description"]}
+            # receptorOrLocusType is a special case, but otherwise the pattern is:
+            # "values" can be an actual type, like bool, or is assumed to be a
+            # list of possible values.  In the latter case the type is taken to
+            # be the inferred type of the first entry in the list.
             if optname != "receptorOrLocusType":
                 if isinstance(opt["values"], type):
                     args["type"] = opt["values"]
                 else:
                     args["choices"] = opt["values"]
+                    args["type"] = type(opt["values"][0])
                     # Maybe helpful for long lists:
                     # https://stackoverflow.com/a/16985727/4499968
             option_parser.add_argument("--" + optname, **args)


### PR DESCRIPTION
Sets the expected object type for command-line arguments based on the list of expected values (for cases where there's a list of allowed values from VQUEST). Fixes #4.