### PR TITLE
Improve description for "Your Selection" section used in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@
 ### Changed
 
  * Reorganized and expanded test code as its own package ([#6])
+ * Clarified wording on required options ([#8])
 
 ### Fixed
 
  * Parse command-line options that should be integers from a finite list of
    options as integers instead of strings ([#5])
 
+[#8]: https://github.com/ressy/vquest/pull/8
 [#7]: https://github.com/ressy/vquest/pull/7
 [#6]: https://github.com/ressy/vquest/pull/6
 [#5]: https://github.com/ressy/vquest/pull/5

--- a/vquest/data/options.yml
+++ b/vquest/data/options.yml
@@ -1,5 +1,8 @@
 - section: Your Selection
-  description: Main V-QUEST options.  These and options in the sections below can be given as individual arguments and will override options supplied via config files.  The options in this section must be specified while the others are optional.
+  # The options in this section must be specified while the others are
+  # optional.  A number of these have defaults defined in defaults.yml but some
+  # (e.g. species) must be given explicitly.
+  description: Main V-QUEST options.  These and options in the sections below can be given as individual arguments and will override options supplied via config files.
   options:
     receptorOrLocusType:
       # by species.  need to split into lists


### PR DESCRIPTION
Removes a confusing mention of required options that do mostly have defaults.  Fixes #2.