### PR TITLE
Try running package on command line during automated testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ jobs:
       - run:
           command: python -m unittest
           name: Test
+      - run:
+          command: python -m vquest -h
+          name: Try CLI
 
 workflows:
   main:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
  * Reorganized and expanded test code as its own package ([#6])
+ * Added basic test of command-line usage ([#10])
  * Clarified wording on required options ([#8])
 
 ### Fixed
@@ -19,6 +20,7 @@
  * Parse command-line options that should be integers from a finite list of
    options as integers instead of strings ([#5])
 
+[#10]: https://github.com/ressy/vquest/pull/10
 [#8]: https://github.com/ressy/vquest/pull/8
 [#7]: https://github.com/ressy/vquest/pull/7
 [#6]: https://github.com/ressy/vquest/pull/6


### PR DESCRIPTION
Adds a second CircleCI step to just ask for the help text (`python -m vquest -h`) and confirm a zero exit code.  Fixes #9.