### PR TITLE
Fix batch submission of sequences for perfect multiples of 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## dev
+
+### Fixed
+
+ * Don't include a trailing empty submission when submitting perfect multiples
+   of 50 sequences ([#19])
+
+[#19]: https://github.com/ressy/vquest/pull/19
+
 ## 0.0.7 - 2021-03-17
 
 ### Fixed

--- a/test_vquest/test_util.py
+++ b/test_vquest/test_util.py
@@ -1,0 +1,26 @@
+"""
+Test util functions.
+"""
+
+import unittest
+from vquest import util
+
+class TestChunker(unittest.TestCase):
+    """Basic test of iterator chunker."""
+
+    def test_chunker(self):
+        """Test that chunker breaks iterator items into fixed-size chunks."""
+        chunks = []
+        for chunk in util.chunker(range(8), 5):
+            chunks.append(chunk)
+        self.assertEqual([[0, 1, 2, 3, 4], [5, 6, 7]], chunks)
+
+class TestChunkerPerfectFit(unittest.TestCase):
+    """Test chunker for a perfect fit, with number of items equal to chunk size."""
+
+    def test_chunker(self):
+        """Test that chunker gives only one chunk for the perfect-fit case."""
+        chunks = []
+        for chunk in util.chunker(range(5), 5):
+            chunks.append(chunk)
+        self.assertEqual([[0, 1, 2, 3, 4]], chunks)

--- a/vquest/util.py
+++ b/vquest/util.py
@@ -22,7 +22,10 @@ def chunker(iterator, chunksize):
                 chunk = []
     except StopIteration:
         pass
-    yield chunk
+    # If the last chunk has items, yield that, but don't just yield an empty
+    # list.
+    if chunk:
+        yield chunk
 
 def unzip(txt):
     """Extract .zip data from bytes into dict keyed on filenames."""


### PR DESCRIPTION
Updates `util.chunker` so that sequences submitted in multiples of 50 will no longer include a trailing empty submission.  Fixes #18.