### PR TITLE
Allow raw un-combined output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
  * `--outdir` argument to set output directory other than current working
    directory ([#24])
+ * `--no-collapse` argument (and updates to `request` function) to disable
+   automatic combining of results across batched submissions ([#25])
 
+[#25]: https://github.com/ressy/vquest/pull/25
 [#24]: https://github.com/ressy/vquest/pull/24
 
 ## 0.0.8 - 2021-07-13

--- a/test_vquest/test_vquest.py
+++ b/test_vquest/test_vquest.py
@@ -140,6 +140,13 @@ CC
         deletions = result["vquest_airr.tsv"].splitlines()[1].split("\t")[123]
         self.assertEqual(seq_analysis_cat, "1 (noindelsearch)")
         self.assertEqual(deletions, "")
+        # Also try with collapse=False, for raw output
+        result = vquest(config, collapse=False)
+        self.assertEqual(self.post.call_count, 2)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            list(result[0].keys()),
+            ["Parameters.txt", "vquest_airr.tsv"])
 
     def test_vquest_main(self):
         """Test that the command-line interface gives the expected response."""
@@ -149,6 +156,12 @@ CC
             main([config_path])
             self.assertTrue(Path("vquest_airr.tsv").exists())
             self.assertTrue(Path("Parameters.txt").exists())
+        # also test with the raw output enabled
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chdir(tempdir)
+            main(["--no-collapse", config_path])
+            self.assertTrue(Path("001/vquest_airr.tsv").exists())
+            self.assertTrue(Path("001/Parameters.txt").exists())
 
     def test_vquest_main_alignment(self):
         """Try using the --align feature.


### PR DESCRIPTION
Adds a command-line option `--no-collapse` and adds to `vquest.request` to allow output to stay in separate batches without modification from IMGT.  Fixes #23.