### PR TITLE
Handle empty configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@
 
 ### Fixed
 
+ * Empty config files now result in the usual error message about required
+   options ([#30])
  * All command-line options now match V-QUEST option names ([#28])
 
+[#30]: https://github.com/ressy/vquest/pull/30
 [#28]: https://github.com/ressy/vquest/pull/28
 [#25]: https://github.com/ressy/vquest/pull/25
 [#24]: https://github.com/ressy/vquest/pull/24

--- a/test_vquest/test_vquest.py
+++ b/test_vquest/test_vquest.py
@@ -218,9 +218,6 @@ class TestVquestEmpty(TestVquestSimple):
     def test_vquest_no_collapse(self):
         self.check_missing_defaults(lambda: vquest(self.config, collapse=False))
 
-    # this requires a fix in __setup_config to intercept and filter None
-    # objects in the config list.
-    @unittest.expectedFailure
     def test_vquest_main(self):
         self.check_missing_defaults(lambda: main([str(self.path / "config.yml")]))
 

--- a/vquest/__main__.py
+++ b/vquest/__main__.py
@@ -46,9 +46,12 @@ def __setup_config(args, parser):
     # given as command line arguments
     configs = [load_config(config) for config in args.config]
     for filename, config in zip(args.config, configs):
-        LOGGER.debug("options via %s: %s",
-            filename,
-            " ".join(["%s=%s" % (key, val) for key, val in config.items()]))
+        if config:
+            msg = " ".join(["%s=%s" % (key, val) for key, val in config.items()])
+        else:
+            msg = "(empty config)"
+        LOGGER.debug("options via %s: %s", filename, msg)
+    configs = [config for config in configs if config]
     LOGGER.debug("overriding command-line options: %s",
         " ".join(["%s=%s" % (key, val) for key, val in vquest_args.items()]))
     config_full = layer_configs(DEFAULTS, *configs, vquest_args)


### PR DESCRIPTION
If an empty config file is given, this will now give `ValueError: species, receptorOrLocusType, and fileSequences and/or sequences are required options` instead of `AttributeError: 'NoneType' object has no attribute 'items'`.  Fixes #29.