### PR TITLE
Fix usage example and imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## dev
 
+### Changed
+
+ * Repository now at <https://github.com/ShawHahnLab/vquest> ([#36])
+
 ### Fixed
 
+ * Usage example now matches packaged structure ([#36])
  * Requests to the IMGT server now use HTTPS ([#34])
 
+[#36]: https://github.com/ShawHahnLab/vquest/pull/36
 [#34]: https://github.com/ressy/vquest/pull/34
 
 ## 0.0.9 - 2021-07-20

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Automate IMGT V-QUEST usage on imgt.org
 
-[![vquest](https://circleci.com/gh/ressy/vquest.svg?style=shield)](https://circleci.com/gh/ressy/vquest)
+[![vquest](https://circleci.com/gh/shawhahnlab/vquest.svg?style=shield)](https://circleci.com/gh/shawhahnlab/vquest)
 
 [IMGT](http://imgt.org)'s [V-QUEST](http://www.imgt.org/IMGT_vquest/analysis)
 is only available via a web interface.  This Python package automates V-QUEST

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Automate IMGT V-QUEST usage on imgt.org
 
-[![vquest](https://circleci.com/gh/shawhahnlab/vquest.svg?style=shield)](https://circleci.com/gh/shawhahnlab/vquest)
+[![vquest](https://circleci.com/gh/ShawHahnLab/vquest.svg?style=shield)](https://circleci.com/gh/ShawHahnLab/vquest)
 
 [IMGT](http://imgt.org)'s [V-QUEST](http://www.imgt.org/IMGT_vquest/analysis)
 is only available via a web interface.  This Python package automates V-QUEST

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here the aligned FASTA text is printed directly to standard output.
 
 Example Python usage:
 
-    >>> from vquest import *
+    >>> from vquest.vq import *
     >>> config = layer_configs(DEFAULTS, {"species": "rhesus-monkey", "receptorOrLocusType": "IG", "fileSequences": "seqs.fasta"})
     >>> result = vquest(config)
     >>> result.keys()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     description="Automate IMGT V-QUEST usage on imgt.org",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/ressy/vquest",
+    url="https://github.com/shawhahnlab/vquest",
     packages=setuptools.find_packages(),
     package_data={"vquest": ["data/*"]},
     entry_points={"console_scripts": [

--- a/vquest/__init__.py
+++ b/vquest/__init__.py
@@ -6,6 +6,8 @@ http://www.imgt.org/IMGT_vquest/analysis
 
 import logging
 from .version import __version__
+from .request import vquest
+from .config import DEFAULTS, OPTIONS, load_config, layer_configs
 LOGGER = logging.getLogger(__name__)
 LOGGER.propagate = False
 LOGGER.addHandler(logging.StreamHandler())

--- a/vquest/__init__.py
+++ b/vquest/__init__.py
@@ -6,8 +6,6 @@ http://www.imgt.org/IMGT_vquest/analysis
 
 import logging
 from .version import __version__
-from .request import vquest
-from .config import DEFAULTS, OPTIONS, load_config, layer_configs
 LOGGER = logging.getLogger(__name__)
 LOGGER.propagate = False
 LOGGER.addHandler(logging.StreamHandler())

--- a/vquest/__main__.py
+++ b/vquest/__main__.py
@@ -6,9 +6,9 @@ import sys
 import logging
 import argparse
 from pathlib import Path
-import vquest
+from vquest import __doc__ as main_doc
 from vquest import LOGGER
-from . import request
+from .request import vquest
 from .config import DEFAULTS, OPTIONS, load_config, layer_configs
 from .util import airr_to_fasta
 from .version import __version__
@@ -23,7 +23,7 @@ def main(arglist=None):
         args = parser.parse_args(arglist)
     LOGGER.setLevel(max(10, logging.WARNING - 10*args.verbose))
     config_full = __setup_config(args, parser)
-    output = request.vquest(config_full, collapse=args.collapse)
+    output = vquest(config_full, collapse=args.collapse)
     __process_output(args, output)
     LOGGER.info("Done.")
 
@@ -84,7 +84,7 @@ def __process_output(args, output):
 
 def __setup_arg_parser():
     parser = argparse.ArgumentParser(
-        description=vquest.__doc__,
+        description=main_doc,
         formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("config", nargs="*", help="YAML configuration file")
     parser.add_argument(

--- a/vquest/__main__.py
+++ b/vquest/__main__.py
@@ -8,10 +8,7 @@ import argparse
 from pathlib import Path
 from vquest import __doc__ as main_doc
 from vquest import LOGGER
-from .request import vquest
-from .config import DEFAULTS, OPTIONS, load_config, layer_configs
-from .util import airr_to_fasta
-from .version import __version__
+from vquest import vq
 
 def main(arglist=None):
     """Command-line interface for V-QUEST requests"""
@@ -23,7 +20,7 @@ def main(arglist=None):
         args = parser.parse_args(arglist)
     LOGGER.setLevel(max(10, logging.WARNING - 10*args.verbose))
     config_full = __setup_config(args, parser)
-    output = vquest(config_full, collapse=args.collapse)
+    output = vq.vquest(config_full, collapse=args.collapse)
     __process_output(args, output)
     LOGGER.info("Done.")
 
@@ -32,7 +29,7 @@ def __setup_config(args, parser):
     # All the possible vquest options.  They're grouped by section as the keys
     # to inner dictionaries.
     vquest_opts = []
-    for opt_section in OPTIONS:
+    for opt_section in vq.OPTIONS:
         vquest_opts.extend(opt_section["options"].keys())
     vquest_args = {k: v for k, v in args_set.items() if k in vquest_opts}
     # If no config file(s) and no vquest args were given, just print the help
@@ -44,7 +41,7 @@ def __setup_config(args, parser):
         " ".join(["%s=%s" % (key, val) for key, val in args_set.items()]))
     # Overlay the default config, configs given as files, and then options
     # given as command line arguments
-    configs = [load_config(config) for config in args.config]
+    configs = [vq.load_config(config) for config in args.config]
     for filename, config in zip(args.config, configs):
         if config:
             msg = " ".join(["%s=%s" % (key, val) for key, val in config.items()])
@@ -54,7 +51,7 @@ def __setup_config(args, parser):
     configs = [config for config in configs if config]
     LOGGER.debug("overriding command-line options: %s",
         " ".join(["%s=%s" % (key, val) for key, val in vquest_args.items()]))
-    config_full = layer_configs(DEFAULTS, *configs, vquest_args)
+    config_full = vq.layer_configs(vq.DEFAULTS, *configs, vquest_args)
     LOGGER.debug("final config: %s",
         " ".join(["%s=%s" % (key, val) for key, val in config_full.items()]))
     LOGGER.info("Configuration prepared")
@@ -63,7 +60,7 @@ def __setup_config(args, parser):
 def __process_output(args, output):
     if args.align:
         LOGGER.info("Writing FASTA to stdout")
-        print(airr_to_fasta(output["vquest_airr.tsv"]), end="")
+        print(vq.airr_to_fasta(output["vquest_airr.tsv"]), end="")
     else:
         args.outdir.mkdir(parents=True, exist_ok=True)
         if args.collapse:
@@ -91,7 +88,7 @@ def __setup_arg_parser():
         "--verbose", "-v", action="count", default=0,
         help="increase logging verbosity")
     parser.add_argument(
-        "--version", "-V", action="version", version=__version__)
+        "--version", "-V", action="version", version=vq.__version__)
     parser.add_argument(
         "--outdir", "-o", default=".", type=Path, help="directory for output files (. by default)")
     # https://stackoverflow.com/a/52403318/4499968
@@ -108,7 +105,7 @@ def __setup_arg_parser():
             "from AIRR results and print as FASTA.  "
             "If there is no text in the sequence_alignment column "
             "for a given sequence the original sequence is used instead."))
-    for opt_section in OPTIONS:
+    for opt_section in vq.OPTIONS:
         option_parser = parser.add_argument_group(
             title="V-QUEST options: \"%s\" section" % opt_section["section"],
             description=opt_section["description"])

--- a/vquest/request.py
+++ b/vquest/request.py
@@ -94,4 +94,8 @@ def _collapse_outputs(outputs):
         else:
             airr = output_chunk["vquest_airr.tsv"].decode()
             output["vquest_airr.tsv"] += "\n".join(airr.splitlines()[1:])
+        # I've seen cases where there may or may not be a final newline, so
+        # let's make sure there always is
+        if not output["vquest_airr.tsv"].endswith("\n"):
+            output["vquest_airr.tsv"] += "\n"
     return output

--- a/vquest/vq.py
+++ b/vquest/vq.py
@@ -1,0 +1,7 @@
+"""
+Common imports grouped here for convenience.
+"""
+from .request import vquest
+from .config import DEFAULTS, OPTIONS, load_config, layer_configs
+from .util import airr_to_fasta
+from .version import __version__


### PR DESCRIPTION
This groups common within-package imports into `vquest.vq` and updates the README example to match.  Fixes #35.

While I'm at it I also updated URLs for the new repo location, and included one maybe-fix for a sporadic problem with newlines in IMGT-supplied text output (c12319ad65e8d3c2da1720fb6b014eb6b75b9cfe) just to get that out the door.