### PR TITLE
Revert unnecessary changes handling plain tsv vs zip archive

### DIFF
--- a/test_vquest/test_vquest.py
+++ b/test_vquest/test_vquest.py
@@ -130,9 +130,12 @@ CC
             {"data": config_used})
         self.assertEqual(
             list(result.keys()),
-            ["vquest_airr.tsv"])
+            ["Parameters.txt", "vquest_airr.tsv"])
+        with open(self.path / "expected/Parameters.txt") as f_in:
+            parameters = f_in.read()
         with open(self.path / "expected/vquest_airr.tsv") as f_in:
             vquest_airr = f_in.read()
+        self.assertEqual(parameters, result["Parameters.txt"])
         self.assertEqual(vquest_airr, result["vquest_airr.tsv"])
 
     def test_vquest_no_collapse(self):
@@ -143,7 +146,7 @@ CC
         self.assertEqual(len(result), 1)
         self.assertEqual(
             list(result[0].keys()),
-            ["vquest_airr.tsv"])
+            ["Parameters.txt", "vquest_airr.tsv"])
 
     def test_vquest_main(self):
         """Test that the command-line interface gives the expected response."""
@@ -151,6 +154,7 @@ CC
             os.chdir(tempdir)
             main([str(self.path / "config.yml")])
             self.assertTrue(Path("vquest_airr.tsv").exists())
+            self.assertTrue(Path("Parameters.txt").exists())
 
     def test_vquest_main_no_collapse(self):
         """Test command-line interface with --no-collapse."""
@@ -158,6 +162,7 @@ CC
             os.chdir(tempdir)
             main(["--no-collapse", str(self.path / "config.yml")])
             self.assertTrue(Path("001/vquest_airr.tsv").exists())
+            self.assertTrue(Path("001/Parameters.txt").exists())
 
     def test_vquest_main_alignment(self):
         """Try using the --align feature.
@@ -266,9 +271,12 @@ CC
             {"data": config_used})
         self.assertEqual(
             list(result.keys()),
-            ["vquest_airr.tsv"])
+            ["Parameters.txt", "vquest_airr.tsv"])
+        with open(self.path / "expected/Parameters.txt") as f_in:
+            parameters = f_in.read()
         with open(self.path / "expected/vquest_airr.tsv") as f_in:
             vquest_airr = f_in.read()
+        self.assertEqual(parameters, result["Parameters.txt"])
         self.assertEqual(vquest_airr, result["vquest_airr.tsv"])
 
     def test_vquest_no_collapse(self):
@@ -279,7 +287,7 @@ CC
         self.assertEqual(len(result), 1)
         self.assertEqual(
             list(result[0].keys()),
-            ["vquest_airr.tsv"])
+            ["Parameters.txt", "vquest_airr.tsv"])
 
     def test_vquest_main(self):
         """Test that the command-line interface gives the expected response."""
@@ -290,6 +298,7 @@ CC
                 f_out.write(f"fileSequences: {self.input_path}\n")
             main(["config.yml"])
             self.assertTrue(Path("vquest_airr.tsv").exists())
+            self.assertTrue(Path("Parameters.txt").exists())
 
     def test_vquest_main_no_collapse(self):
         """Test command-line interface with --no-collapse."""
@@ -300,6 +309,7 @@ CC
                 f_out.write(f"fileSequences: {self.input_path}\n")
             main(["--no-collapse", "config.yml"])
             self.assertTrue(Path("001/vquest_airr.tsv").exists())
+            self.assertTrue(Path("001/Parameters.txt").exists())
 
     def test_vquest_main_alignment(self):
         """Try using the --align feature.
@@ -352,6 +362,7 @@ class TestVquestCustom(TestVquestSimple):
             os.chdir(tempdir)
             main(["--IMGTrefdirSet", "1", str(self.path / "config.yml")])
             self.assertTrue(Path("vquest_airr.tsv").exists())
+            self.assertTrue(Path("Parameters.txt").exists())
 
 
 class TestVquestInvalid(TestVquestBase):

--- a/vquest/__main__.py
+++ b/vquest/__main__.py
@@ -76,8 +76,7 @@ def __process_output(args, output):
                 for key in chunk:
                     output_path = args.outdir / chunkdir / key
                     LOGGER.info("Writing %s", output_path)
-                    mode = "wb" if isinstance(chunk[key], bytes) else "wt"
-                    with open(output_path, mode) as f_out:
+                    with open(output_path, "wb") as f_out:
                         f_out.write(chunk[key])
 
 def __setup_arg_parser():

--- a/vquest/request.py
+++ b/vquest/request.py
@@ -47,17 +47,6 @@ def _parse_records(config):
             records.extend(list(SeqIO.parse(f_in, fmt)))
     return records
 
-def _parse_response(content):
-    """Parse V-QUEST response content.
-
-    Handles both the zip format (V-QUEST < 3.8.0, where xv_outputtype=3
-    returned a zip archive) and the plain TSV format (V-QUEST 3.8.0+, where
-    the same option returns the AIRR TSV directly).
-    """
-    if content[:2] == b"PK":  # ZIP magic bytes
-        return unzip(content)
-    return {"vquest_airr.tsv": content.decode("utf-8")}
-
 def vquest(config, collapse=True):
     """Submit a request to V-QUEST.
 
@@ -71,7 +60,7 @@ def vquest(config, collapse=True):
     as though they were submitted and processed as a single request, and a
     dictionary of file names to text contents is returned.  If collapse is
     False, a list of dictionaries is returned, one for each batch, storing raw
-    byte contents (zip format) or text strings (plain TSV format).
+    byte contents.
     """
     if not all([
         config.get("species"),
@@ -82,9 +71,6 @@ def vquest(config, collapse=True):
             "and/or sequences are required options")
     supported = [("resultType", "excel"), ("xv_outputtype", 3)]
     if all([config.get(pair[0]) == pair[1] for pair in supported]):
-        # Default moleculeType to Unknown if not set (required by V-QUEST 3.8.0+)
-        if "moleculeType" not in config:
-            config = {**config, "moleculeType": "Unknown"}
         outputs = []
         records = _parse_records(config)
         if not records:
@@ -107,7 +93,7 @@ def vquest(config, collapse=True):
                 errors = [div.text for div in html.find("div.form_error")]
                 if errors:
                     raise VquestError("; ".join(errors), errors)
-            outputs.append(_parse_response(response.content))
+            outputs.append(unzip(response.content))
         if not collapse:
             return outputs
         return _collapse_outputs(outputs)
@@ -119,19 +105,17 @@ def _collapse_outputs(outputs):
     """Combine batched output dictionaries into one."""
     output = {}
     for output_chunk in outputs:
-        # Parameters.txt is only present in the old zip format; keep one copy if available
-        if "Parameters.txt" in output_chunk and "Parameters.txt" not in output:
-            data = output_chunk["Parameters.txt"]
-            output["Parameters.txt"] = data.decode() if isinstance(data, bytes) else data
-        # Append AIRR TSV rows together (skip header on subsequent batches)
+        # Only keep one copy of the Parameters.txt data, but append rows
+        # (minus header) of vquest_airr.tsv together
+        if "Parameters.txt" not in output:
+            output["Parameters.txt"] = output_chunk["Parameters.txt"].decode()
         if "vquest_airr.tsv" not in output:
-            data = output_chunk["vquest_airr.tsv"]
-            output["vquest_airr.tsv"] = data.decode() if isinstance(data, bytes) else data
+            output["vquest_airr.tsv"] = output_chunk["vquest_airr.tsv"].decode()
         else:
-            data = output_chunk["vquest_airr.tsv"]
-            airr = data.decode() if isinstance(data, bytes) else data
+            airr = output_chunk["vquest_airr.tsv"].decode()
             output["vquest_airr.tsv"] += "\n".join(airr.splitlines()[1:])
-        # Ensure trailing newline
+        # I've seen cases where there may or may not be a final newline, so
+        # let's make sure there always is
         if not output["vquest_airr.tsv"].endswith("\n"):
             output["vquest_airr.tsv"] += "\n"
     return output

--- a/vquest/request.py
+++ b/vquest/request.py
@@ -71,6 +71,9 @@ def vquest(config, collapse=True):
             "and/or sequences are required options")
     supported = [("resultType", "excel"), ("xv_outputtype", 3)]
     if all([config.get(pair[0]) == pair[1] for pair in supported]):
+        # Default moleculeType to Unknown if not set (required by V-QUEST 3.8.0+)
+        if "moleculeType" not in config:
+            config = {**config, "moleculeType": "Unknown"}
         outputs = []
         records = _parse_records(config)
         if not records:


### PR DESCRIPTION
As promised re: discussion in #40 - some changes in the last PR appear to be unnecessary as vquest is still consistently returning a zip archive. This reverts the scripts to the prior versions before my changes. 